### PR TITLE
django 1.4 compatibility by 'backporting' get_path_info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     long_description=__doc__,
     py_modules=['dj_static'],
     zip_safe=False,
-    install_requires=['static'],
+    install_requires=['static', 'six'],
     include_package_data=True,
     platforms='any',
     classifiers=[


### PR DESCRIPTION
Hej, i'm not sure you even want to support Django 1.4, but if you do, get_path_info needs to be 'backported' (copy&pasted...) :)
