### PR TITLE
Added Python3 support with werkzeug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     long_description=__doc__,
     py_modules=['dj_static'],
     zip_safe=False,
-    install_requires=['static'],
+    install_requires=['werkzeug'],
     include_package_data=True,
     platforms='any',
     classifiers=[
@@ -51,6 +51,9 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
The static library was last touched in 2009 and doesn't support Python3.  I tried to port it, but I wasn't very successful.  The werkzeug library has a very similar middleware which does support Python3.3, so I used that.
