### PR TITLE
point to staticserve as a dependency (Python 3 compatibility)

### DIFF
--- a/dj_static.py
+++ b/dj_static.py
@@ -56,6 +56,7 @@ class Cling(WSGIHandler):
     def __call__(self, environ, start_response):
         # Hand non-static requests to Django
         if not self._should_handle(get_path_info(environ)):
+            print(type(self.application))
             return self.application(environ, start_response)
 
         # Serve static requests from static.Cling

--- a/dj_static.py
+++ b/dj_static.py
@@ -56,7 +56,6 @@ class Cling(WSGIHandler):
     def __call__(self, environ, start_response):
         # Hand non-static requests to Django
         if not self._should_handle(get_path_info(environ)):
-            print(type(self.application))
             return self.application(environ, start_response)
 
         # Serve static requests from static.Cling

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+staticserve

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+requests
+staticserve

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
+django
 requests
 staticserve

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,22 @@
+import sys
+
+from django.conf import settings
+
+settings.configure(
+    DEBUG=True,
+    INSTALLED_APPS=[
+        "django.contrib.contenttypes",
+    ],
+)
+
+from django.test.simple import DjangoTestSuiteRunner
+
+
+def runtests():
+    return DjangoTestSuiteRunner(failfast=False).run_tests([
+        'tests.TestCling'
+    ], verbosity=1, interactive=True)
+
+if __name__ == '__main__':
+    if runtests():
+        sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    test_suite='tests',
+    test_suite='runtests',
 )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,18 @@ Then, update your ``wsgi.py`` file to use dj-static::
 
 """
 
+import sys
+
 from setuptools import setup
+
+
+def get_requirements(filename):
+    return list([x.strip() for x in open(filename).readlines()])
+
+if sys.argv[-1] == 'test':
+    requirements = get_requirements("requirements_test.txt")
+else:
+    requirements = get_requirements("requirements.txt")
 
 setup(
     name='dj-static',
@@ -42,7 +53,7 @@ setup(
     long_description=__doc__,
     py_modules=['dj_static'],
     zip_safe=False,
-    install_requires=['staticserve'],
+    install_requires=requirements,
     include_package_data=True,
     platforms='any',
     classifiers=[
@@ -53,5 +64,6 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
+    ],
+    test_suite='tests',
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     long_description=__doc__,
     py_modules=['dj_static'],
     zip_safe=False,
-    install_requires=['static'],
+    install_requires=['staticserve'],
     include_package_data=True,
     platforms='any',
     classifiers=[

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,7 @@
+import unittest
+
+
+class TestCling(unittest.TestCase):
+
+    def test_a(self):
+        pass

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,13 @@
 import unittest
 
+from django.conf import settings
+
+settings.configure(
+    DEBUG=True,
+    INSTALLED_APPS=[
+        "django.contrib.contenttypes",
+    ],
+)
 
 class TestCling(unittest.TestCase):
 

--- a/tests.py
+++ b/tests.py
@@ -1,13 +1,5 @@
 import unittest
 
-from django.conf import settings
-
-settings.configure(
-    DEBUG=True,
-    INSTALLED_APPS=[
-        "django.contrib.contenttypes",
-    ],
-)
 
 class TestCling(unittest.TestCase):
 


### PR DESCRIPTION
staticserve brings in two new dependencies:
- six for Python 3 compatibility
- werkzueg for just replacing rfc822 usage for date format parsing, nothing else.  FWIW, rfc822 was deprecated as of Python 2.3, about 4-5 years before static was originally written!
