### PR TITLE
Bugfix Cling._transpose_environ and MediaCling.debug_cling

### DIFF
--- a/dj_static.py
+++ b/dj_static.py
@@ -42,7 +42,7 @@ class Cling(WSGIHandler):
 
     def _transpose_environ(self, environ):
         """Translates a given environ to static.Cling's expectations."""
-        environ['PATH_INFO'] = environ['PATH_INFO'][len(self.base_url) + 1:]
+        environ['PATH_INFO'] = environ['PATH_INFO'][len(self.base_url[2]) - 1:]
         return environ
 
     def _should_handle(self, path):

--- a/dj_static.py
+++ b/dj_static.py
@@ -69,7 +69,12 @@ class Cling(WSGIHandler):
 
 class MediaCling(Cling):
 
-    def debug_cling(self, environ, start_response):
+    def __init__(self, application, base_dir=None):
+        super(MediaCling, self).__init__(application, base_dir=base_dir)
+        # override callable attribute with method
+        self.debug_cling = self._debug_cling
+
+    def _debug_cling(self, environ, start_response):
         environ = self._transpose_environ(environ)
         return self.cling(environ, start_response)
 


### PR DESCRIPTION
Bugfixes:
- _transpose_environ treated base_url as a string when it was a tuple. By accident, len('/static/') - 1 == len(base_url) + 1 == 7. Breaks for a url of any other length.
- MediaCling's method declaration of debug_cling was insufficient to override the instance attribute of the same name.  Replaced with explicit declaration.
