### PR TITLE
Make compatible with Django Dev (1.7+)

### DIFF
--- a/dj_static.py
+++ b/dj_static.py
@@ -4,7 +4,10 @@ import static
 
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIHandler
-from django.core.handlers.base import get_path_info
+try:
+    from django.core.handlers.base import get_path_info
+except ImportError:
+    from django.core.handlers.wsgi import get_path_info
 from django.contrib.staticfiles.handlers import StaticFilesHandler as DebugHandler
 
 try:


### PR DESCRIPTION
`get_path_info` was moved from `django.core.handlers.base` to `django.core.handlers.wsgi` in commit 636860f.  See https://github.com/django/django/commit/636860f

Here is a sample patch that illustrates the move, suggests a backwards compatible change.  It may not be the cleanest way to do this, but it illustrates the change required.
