### PR TITLE
Update version to be able to import MediaCling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import setup
 
 setup(
     name='dj-static',
-    version='0.0.5',
+    version='0.0.6',
     url='https://github.com/kennethreitz/dj-static',
     license='BSD',
     author='Kenneth Reitz',


### PR DESCRIPTION
When running `pip install dj-static` it will install the version `0.5`, and we aren't able to import the class `MediaCling`. For those who want to serve media files, images, on Heroku is useful. 
