### PR TITLE
Properly invoke StaticFilesHandler

### DIFF
--- a/dj_static.py
+++ b/dj_static.py
@@ -25,7 +25,7 @@ class Cling(WSGIHandler):
         self.base_url = urlparse(self.get_base_url())
 
         self.cling = static.Cling(base_dir)
-        self.debug_cling = DebugHandler(base_dir)
+        self.debug_cling = DebugHandler(application, base_dir=base_dir)
 
         super(Cling, self).__init__()
 


### PR DESCRIPTION
Currently dj-static uses an inappropriate signature for creating a new StaticFilesHandler, causing it to crash out with the following error: 

```
[ERROR] Error handling request
Traceback (most recent call last):
   File "venv/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 126, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
   File "venv/lib/python2.7/site-packages/dj_static.py", line 67, in __call__
     return self.debug_cling(environ, start_response)
   File "venv/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 72, in __call__
     return self.application(environ, start_response)
 TypeError: 'str' object is not callable
```

This patch corrects that.
