### PR TITLE
Allow base_url to be overridden

### DIFF
--- a/dj_static.py
+++ b/dj_static.py
@@ -34,12 +34,12 @@ class Cling(WSGIHandler):
     """WSGI middleware that intercepts calls to the static files
     directory, as defined by the STATIC_URL setting, and serves those files.
     """
-    def __init__(self, application, base_dir=None, ignore_debug=False):
+    def __init__(self, application, base_dir=None, base_url=None, ignore_debug=False):
         self.application = application
         self.ignore_debug = ignore_debug
         if not base_dir:
             base_dir = self.get_base_dir()
-        self.base_url = urlparse(self.get_base_url())
+        self.base_url = urlparse(base_url or self.get_base_url())
 
         self.cling = static.Cling(base_dir)
         try:


### PR DESCRIPTION
This is useful when STATIC_URL points to S3, but you still want to serve some
static resources from Django.  I'll use it with
base_url=settings.LOCAL_STATIC_URL to work around TinyMCE same origin issues.
