### PR TITLE
Add Django 1.7 support

### DIFF
--- a/dj_static.py
+++ b/dj_static.py
@@ -13,21 +13,25 @@ except ImportError:     # Python 2
 from django.contrib.staticfiles import utils
 
 try:
-    from django.core.handlers.base import get_path_info
-except ImportError:     # django < 1.5
-    import sys
-    py3 = sys.version_info[0] == 3
-    def get_path_info(environ):
-        """
-        Returns the HTTP request's PATH_INFO as a unicode string.
-        """
-        path_info = environ.get('PATH_INFO', str('/'))
-        # Under Python 3, strings in environ are decoded with ISO-8859-1;
-        # re-encode to recover the original bytestring provided by the web server.
-        if py3:
-            path_info = path_info.encode('iso-8859-1')
-        # It'd be better to implement URI-to-IRI decoding, see #19508.
-        return path_info.decode('utf-8')
+    from django.core.handlers.wsgi import get_path_info
+except ImportError:  # django < 1.7
+    try:
+        from django.core.handlers.base import get_path_info
+    except ImportError:     # django < 1.5
+        import sys
+        py3 = sys.version_info[0] == 3
+
+        def get_path_info(environ):
+            """
+            Returns the HTTP request's PATH_INFO as a unicode string.
+            """
+            path_info = environ.get('PATH_INFO', str('/'))
+            # Under Python 3, strings in environ are decoded with ISO-8859-1;
+            # re-encode to recover the original bytestring provided by the web server.
+            if py3:
+                path_info = path_info.encode('iso-8859-1')
+            # It'd be better to implement URI-to-IRI decoding, see #19508.
+            return path_info.decode('utf-8')
 
 
 class Cling(WSGIHandler):


### PR DESCRIPTION
`get_path_info` moved from `django.core.handlers.base` to `django.core.handlers.wsgi` on Django 1.7.

More `ImportError` catching for everyone!
