### PR TITLE
Allow specifying own class to use when creating `dj_static.cling`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,1 @@
+0.1.0: requirements change static3 -> static3-jl

--- a/dj_static.py
+++ b/dj_static.py
@@ -38,14 +38,14 @@ class Cling(WSGIHandler):
     """WSGI middleware that intercepts calls to the static files
     directory, as defined by the STATIC_URL setting, and serves those files.
     """
-    def __init__(self, application, base_dir=None, base_url=None, ignore_debug=False):
+    def __init__(self, application, base_dir=None, base_url=None, ignore_debug=False, cling_class=static.Cling):
         self.application = application
         self.ignore_debug = ignore_debug
         if not base_dir:
             base_dir = self.get_base_dir()
         self.base_url = urlparse(base_url or self.get_base_url())
 
-        self.cling = static.Cling(base_dir)
+        self.cling = cling_class(base_dir)
         try:
             self.debug_cling = DebugHandler(application, base_dir=base_dir)
         except TypeError:
@@ -77,7 +77,7 @@ class Cling(WSGIHandler):
         """
         return path.startswith(self.base_url[2]) and not self.base_url[1]
 
-    def __call__(self, environ, start_response):
+    def __call__(self, environ, start_response, **kwargs):
         # Hand non-static requests to Django
         if not self._should_handle(get_path_info(environ)):
             return self.application(environ, start_response)
@@ -85,7 +85,7 @@ class Cling(WSGIHandler):
         # Serve static requests from static.Cling
         if not self.debug or self.ignore_debug:
             environ = self._transpose_environ(environ)
-            return self.cling(environ, start_response)
+            return self.cling(environ, start_response, **kwargs)
         # Serve static requests in debug mode from StaticFilesHandler
         else:
             return self.debug_cling(environ, start_response)

--- a/dj_static.py
+++ b/dj_static.py
@@ -38,14 +38,14 @@ class Cling(WSGIHandler):
     """WSGI middleware that intercepts calls to the static files
     directory, as defined by the STATIC_URL setting, and serves those files.
     """
-    def __init__(self, application, base_dir=None, base_url=None, ignore_debug=False, cling_class=static.Cling, **kwargs):
+    def __init__(self, application, base_dir=None, base_url=None, ignore_debug=False, cling_class=static.Cling):
         self.application = application
         self.ignore_debug = ignore_debug
         if not base_dir:
             base_dir = self.get_base_dir()
         self.base_url = urlparse(base_url or self.get_base_url())
 
-        self.cling = cling_class(base_dir, **kwargs)
+        self.cling = cling_class(base_dir)
         try:
             self.debug_cling = DebugHandler(application, base_dir=base_dir)
         except TypeError:
@@ -77,7 +77,7 @@ class Cling(WSGIHandler):
         """
         return path.startswith(self.base_url[2]) and not self.base_url[1]
 
-    def __call__(self, environ, start_response, **kwargs):
+    def __call__(self, environ, start_response):
         # Hand non-static requests to Django
         if not self._should_handle(get_path_info(environ)):
             return self.application(environ, start_response)

--- a/dj_static.py
+++ b/dj_static.py
@@ -38,14 +38,14 @@ class Cling(WSGIHandler):
     """WSGI middleware that intercepts calls to the static files
     directory, as defined by the STATIC_URL setting, and serves those files.
     """
-    def __init__(self, application, base_dir=None, base_url=None, ignore_debug=False, cling_class=static.Cling):
+    def __init__(self, application, base_dir=None, base_url=None, ignore_debug=False, cling_class=static.Cling, **kwargs):
         self.application = application
         self.ignore_debug = ignore_debug
         if not base_dir:
             base_dir = self.get_base_dir()
         self.base_url = urlparse(base_url or self.get_base_url())
 
-        self.cling = cling_class(base_dir)
+        self.cling = cling_class(base_dir, **kwargs)
         try:
             self.debug_cling = DebugHandler(application, base_dir=base_dir)
         except TypeError:
@@ -85,7 +85,7 @@ class Cling(WSGIHandler):
         # Serve static requests from static.Cling
         if not self.debug or self.ignore_debug:
             environ = self._transpose_environ(environ)
-            return self.cling(environ, start_response, **kwargs)
+            return self.cling(environ, start_response)
         # Serve static requests in debug mode from StaticFilesHandler
         else:
             return self.debug_cling(environ, start_response)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-dj-static
-~~~~~~~~~
+dj-static-jl
+~~~~~~~~~~~~
+
+This is a modification of the original dj-static by Kenneth Reitz (https://pypi.python.org/pypi/dj-static)
 
 This is a simple Django middleware utility that allows you to properly
 serve static assets from production with a WSGI server like Gunicorn.
@@ -27,22 +29,33 @@ Then, update your ``wsgi.py`` file to use dj-static::
 
     application = Cling(get_wsgi_application())
 
+or::
+
+    from django.core.wsgi import get_wsgi_application
+    from dj_static import Cling
+    import static
+
+    class BaseCling(static.Cling):
+        ...
+
+    application = Cling(get_wsgi_application(), cling_class=BaseCling)
+
 """
 
 from setuptools import setup
 
 setup(
-    name='dj-static',
-    version='0.0.6',
-    url='https://github.com/kennethreitz/dj-static',
+    name='dj-static-jl',
+    version='0.1.0',
+    url='https://github.com/jlachowski/dj-static',
     license='BSD',
-    author='Kenneth Reitz',
-    author_email='me@kennethreitz.com',
+    author='Jaroslaw Lachowski',
+    author_email='jalachowski@gmail.com',
     description='Serve production static files with Django.',
     long_description=__doc__,
     py_modules=['dj_static'],
     zip_safe=False,
-    install_requires=['static3'],
+    install_requires=['static3-jl'],
     include_package_data=True,
     platforms='any',
     classifiers=[


### PR DESCRIPTION
This change enables use of own "static.Cling" class when creating `dj_static.cling` with "static.Cling" being the default setting
