### PR TITLE
Pass all malformed requests to Django.

### DIFF
--- a/dj_static.py
+++ b/dj_static.py
@@ -79,7 +79,12 @@ class Cling(WSGIHandler):
 
     def __call__(self, environ, start_response):
         # Hand non-static requests to Django
-        if not self._should_handle(get_path_info(environ)):
+        try:
+            if not self._should_handle(get_path_info(environ)):
+                return self.application(environ, start_response)
+        except UnicodeDecodeError:
+            # Apparently a malformed URL. Just hand it to Django
+            # for it to respond as it sees fit.
             return self.application(environ, start_response)
 
         # Serve static requests from static.Cling


### PR DESCRIPTION
If get_path_info raises a UnicodeDecodeError, it means the URL
was malformed. Django usually handles this with a 400 Bad Request
response. If dj_static is in use, it will instead choke on the
exception, generating a 500 response.

This change makes it so that, if dj_static sees the UnicodeDecodeError,
it will just give up and pass it to Django to handle. We then rely on
Django's behavior (which as-is, will quickly enter the fail path and
return the 400) to handle this malformed request.

Django's behavior seems correct per
https://code.djangoproject.com/ticket/25623?cversion=0&cnum_hist=2

To test this behavior:
- Create a django app
- Add dj_static per its readme
- Serve the app with gunicorn (doesn't affect the built-in web server)
- Try to load a malformed url (http://localhost:8000/foo%C0)
  You should get a 500 error/crash. With this patch applied, you'll get a 400 status code instead.
