### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Static responses aren't very different than dynamic ones.
 
 If you're running a top-tier application, optimizing for delivery and reducing
 frontend load, you will want to explore using a CDN with
-`Django-Storages <http://django-storages.readthedocs.org/en/latest/>`_.
+`Django-Storages <https://django-storages.readthedocs.io/en/latest/>`_.
 
 
 Usage


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
