### PR TITLE
update link to django documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ DJ-Static
 This is a simple Django middleware utility that allows you to properly
 serve static assets from production with a WSGI server like Gunicorn.
 
-Django `doesn't recommend <https://docs.djangoproject.com/en/1.5/howto/static-files/#admonition-serving-the-files>`_
+Django `doesn't recommend <https://docs.djangoproject.com/en/dev/howto/static-files/#admonition-serving-the-files>`_
 the production use of its static file server for a number of reasons.
 There exists, however, a lovely WSGI application aptly named `Static <https://pypi.python.org/pypi/static>`_.
 


### PR DESCRIPTION
Link to django documentation updated to development version, so link is always available to latest version